### PR TITLE
fix: INTE-921 add vendorId and definitionId to exported metadata

### DIFF
--- a/profile-tools/CHANGELOG.md
+++ b/profile-tools/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Profile tools
 
+## 1.3.1
+
+8 July 2025
+
+* Add vendorId and definitionId to exported metadata to enable attribute
+  matching when metaDatumId is different coming from an external subProject
+
 ## 1.3.0
 
 11 December 2024

--- a/profile-tools/package-lock.json
+++ b/profile-tools/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xvisionas/profile-tools",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@xvisionas/profile-tools",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "devDependencies": {
         "nock": "^14.0.0-beta.15"

--- a/profile-tools/package.json
+++ b/profile-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xvisionas/profile-tools",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "FieldTwin connection profile and metadata export tools",
   "main": "src/index.js",
   "type": "module",

--- a/profile-tools/src/profile.js
+++ b/profile-tools/src/profile.js
@@ -489,6 +489,8 @@ export class ProfileExporter {
         if (value !== undefined && value !== null) {
           attributes.push({
             metaDatumId: metadataValue.metaDatumId,
+            vendorId: metadataValue.vendorId,
+            definitionId: metadataValue.definitionId,
             name: metadataValue.name || '',
             value: value,
             unit: metadataValue.option || '',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Attribute exports now include additional fields for `vendorId` and `definitionId`, providing more detailed metadata.
* **Documentation**
  * Updated changelog to reflect the new version and recent changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->